### PR TITLE
Fix caption selector

### DIFF
--- a/teams-captions-saver/content_script.js
+++ b/teams-captions-saver/content_script.js
@@ -50,6 +50,13 @@ function checkCaptions() {
         const transcript = textElement.closest('.fui-ChatMessageCompact');
         if (!transcript) continue;
         
+        // Generate a unique ID for the transcript element if it doesn't have one
+        // This handles Teams removing caption IDs
+        if (!transcript.getAttribute('data-caption-id')) {
+            const uniqueId = `caption_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+            transcript.setAttribute('data-caption-id', uniqueId);
+        }
+        
         const authorElement = transcript.querySelector('[data-tid="author"]');
         if (!authorElement) continue;
         
@@ -127,6 +134,13 @@ function checkRecentCaptions() {
             const transcript = textElement.closest('.fui-ChatMessageCompact');
             if (!transcript) continue;
             
+            // Generate a unique ID for the transcript element if it doesn't have one
+            // This handles Teams removing caption IDs
+            if (!transcript.getAttribute('data-caption-id')) {
+                const uniqueId = `caption_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+                transcript.setAttribute('data-caption-id', uniqueId);
+            }
+            
             const authorElement = transcript.querySelector('[data-tid="author"]');
             if (!authorElement) continue;
             
@@ -196,7 +210,22 @@ function startTranscription() {
         return false;
     }
 
-    const closedCaptionsContainer = document.querySelector("[data-tid='closed-captions-renderer']");
+    // Use multiple selectors to find captions container (resilient to Teams UI changes)
+    const captionSelectors = [
+        "[data-tid='closed-caption-v2-window-wrapper']",  // Teams v2 wrapper
+        "[data-tid='closed-captions-renderer']",          // Original selector
+        "[data-tid*='closed-caption']"                    // Wildcard fallback
+    ];
+    
+    let closedCaptionsContainer = null;
+    for (const selector of captionSelectors) {
+        closedCaptionsContainer = document.querySelector(selector);
+        if (closedCaptionsContainer) {
+            console.log(`Found captions container using selector: ${selector}`);
+            break;
+        }
+    }
+    
     if (!closedCaptionsContainer) {
         console.log("Please, click 'More' > 'Language and speech' > 'Turn on live captions'");
         setTimeout(startTranscription, 5000);

--- a/teams-captions-saver/content_script.js
+++ b/teams-captions-saver/content_script.js
@@ -344,7 +344,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             // Sort transcripts by the order they appear on screen (not by capture time)
             const orderedForDownload = sortTranscriptsByScreenOrder();
             
-            let meetingTitle = document.title.replace("__Microsoft_Teams", '').replace(/[^a-z0-9 ]/gi, '');
+            let meetingTitle = document.title
+                .replace("__Microsoft_Teams", '')
+                .replace(/[^a-z0-9 ]/gi, ' ')  // Replace special chars with space
+                .replace(/\s+/g, ' ')           // Collapse multiple spaces into one
+                .trim();                        // Remove leading/trailing spaces
             chrome.runtime.sendMessage({
                 message: "download_captions",
                 transcriptArray: orderedForDownload.map(({ID, ...rest}) => rest), // Remove ID property


### PR DESCRIPTION
# Pull Request: Fix caption detection and filename formatting issues

## Problems Fixed
1. **Issue #20**: Users experiencing "Oops! No captions were captured" error intermittently due to:
   - MS Teams removing unique caption IDs from HTML elements
   - Single-point-of-failure selector breaking with Teams UI updates

2. **Filename formatting**: Saved files have multiple spaces in filename when title contains pipe characters

## Solution
This PR implements a more resilient caption detection mechanism with minimal changes:

### 1. Multi-selector approach
Instead of using a single selector that can break:
```javascript
// OLD - Single point of failure
const closedCaptionsContainer = document.querySelector("[data-tid='closed-captions-renderer']");
```

Now uses multiple fallback selectors:
```javascript
// NEW - Multiple fallbacks for resilience
const captionSelectors = [
    "[data-tid='closed-caption-v2-window-wrapper']",  // Teams v2 wrapper
    "[data-tid='closed-captions-renderer']",          // Original selector
    "[data-tid*='closed-caption']"                    // Wildcard fallback
];
```

### 2. Dynamic ID generation
Since Teams removed caption IDs, we now generate our own:
```javascript
if (!transcript.getAttribute('data-caption-id')) {
    const uniqueId = `caption_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
    transcript.setAttribute('data-caption-id', uniqueId);
}
```

### 3. Filename cleanup
Fixed filename generation to properly handle special characters:
```javascript
// OLD - Leaves multiple spaces
let meetingTitle = document.title.replace("__Microsoft_Teams", '').replace(/[^a-z0-9 ]/gi, '');

// NEW - Clean single spaces
let meetingTitle = document.title
    .replace("__Microsoft_Teams", '')
    .replace(/[^a-z0-9 ]/gi, ' ')  // Replace special chars with space
    .replace(/\s+/g, ' ')           // Collapse multiple spaces into one
    .trim();                        // Remove leading/trailing spaces
```

## Changes
- **Lines 199-219**: Updated `startTranscription()` to use multiple selectors with fallback
- **Lines 53-58**: Added ID generation in `checkCaptions()` 
- **Lines 137-142**: Added ID generation in `checkRecentCaptions()`
- **Lines 347-351**: Fixed filename generation to remove multiple spaces

## Testing
- Tested with latest Teams version (August 2025)
- Verified caption capture works consistently across multiple meetings
- No longer experiencing the intermittent failure issue
- Backward compatible with existing functionality

## Impact
- Minimal code changes (approximately 30 lines)
- No changes to extension architecture or other features
- Improves reliability without adding complexity
- Should resolve the issue for all affected users

Fixes #20