### PR TITLE
Fix invalid content_scripts match pattern

### DIFF
--- a/teams-captions-saver/manifest.json
+++ b/teams-captions-saver/manifest.json
@@ -41,7 +41,7 @@
       "matches": [
         "https://teams.microsoft.com/*",
         "https://teams.cloud.microsoft/*",
-        "https://teams.live.com*"
+        "https://teams.live.com/*"
       ],
       "js": [
         "content_script.js"


### PR DESCRIPTION
## Summary
- Fixed missing `/` in `content_scripts[0].matches[2]` pattern (`https://teams.live.com*` → `https://teams.live.com/*`)
- This caused Chrome to reject the extension with "Invalid value for 'content_scripts[0].matches[2]': Empty path"

## Test plan
- [ ] Load unpacked extension in Chrome — should load without errors
- [ ] Verify content script injects on `teams.live.com` meetings

🤖 Generated with [Claude Code](https://claude.com/claude-code)